### PR TITLE
Add in-memory cache of five minutes to overview route

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ app.use(bodyParser.urlencoded({extended: false}))
 app.use(bodyParser.json())
 app.use(express.static('website'))
 app.use(express.static(__dirname + '/images'));
+
+// Cache all routes. By default, the cache TTL is one hour
+app.use(cache())
 // Spin up the server
 app.listen(app.get('port'), function() {
     console.log('running on port', app.get('port'))
@@ -77,7 +80,7 @@ app.get('/',function(req,res){
 /* Parameters:
     Date (optional)
 */
-app.get('/overview', cache('5 minutes'), function (req, res) {
+app.get('/overview', function (req, res) {
     var dateString = getDate(req, res)
 
     var url = util.format(overviewUrl, dateString)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var util = require('util')
 var cheerio = require('cheerio')
 var tabletojson = require('tabletojson');
 var fs = require('fs');
+var apicache = require('apicache');
+
+var cache = apicache.middleware;
 var app = express()
 
 /* 
@@ -74,7 +77,7 @@ app.get('/',function(req,res){
 /* Parameters:
     Date (optional)
 */
-app.get('/overview', function (req, res) {
+app.get('/overview', cache('5 minutes'), function (req, res) {
     var dateString = getDate(req, res)
 
     var url = util.format(overviewUrl, dateString)

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-  	"underscore": "^1.8.3",
-  	"express": "^4.13.4",
+    "apicache": "^1.1.0",
     "body-parser": "^1.15.0",
-    "request": "^2.72.0",
-    "util": "^0.10.3",
     "cheerio": "^0.22.0",
-    "tabletojson": "^0.4.0"
+    "express": "^4.13.4",
+    "request": "^2.72.0",
+    "tabletojson": "^0.4.0",
+    "underscore": "^1.8.3",
+    "util": "^0.10.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This is a really awesome API! I can see a lot of great applications being built off of it since its really easy to use and the response data is straightforward.

I suggest adding a cache to your overview route since it has to parse a lot of raw data on each request. The [apicache](https://github.com/kwhitley/apicache) npm module is really lightweight (compared to something like memcached) and is simple enough for this use case. When I use the API, making a request to the `/overview` route takes a couple of seconds to respond, but returning the cached version is much faster. 

Great stuff!